### PR TITLE
Fix spm list_installed action and error message

### DIFF
--- a/spm
+++ b/spm
@@ -37,6 +37,10 @@ list_available() {
     ls -1 ${_recdir}
 }
 
+list_installed() {
+    cat ${_list} 2> /dev/null
+}
+
 _record_installed() {
     local _pkg=$1
     local _ver=$2
@@ -107,5 +111,5 @@ case $action in
     list_available|list)     list_available ;;
     list_installed)     list_installed ;;
     install)            install $2 ;;
-    *)                  echo "Unknown action: $a"; exit 1; ;;
+    *)                  echo "Unknown action: $action"; exit 1; ;;
 esac


### PR DESCRIPTION
## Summary
- `./spm list_installed` failed with a "command not found" error: the `case` statement in `spm` dispatches to a `list_installed` function that was never defined.
- The unknown-action error branch referenced `$a` instead of `$action`, so it always printed an empty package name.

## Test plan
- [x] `bash -n spm` (syntax check)
- [ ] `./spm list_installed` after installing a package, confirm it prints the recorded `pkg ver` lines
- [ ] `./spm bogus-action`, confirm the error message now names the bad action