### PR TITLE
Fix notary recipe: bare cd extracts sources into $HOME

### DIFF
--- a/recipes/notary
+++ b/recipes/notary
@@ -9,8 +9,7 @@ sha=(ca91d22f017bfcb503d4bc3b44295491c89a33a3df0c3d8b8614f2d3831836eb)
 
 _build() {
     curl -L -O https://github.com/danwent/Perspectives-Server/archive/master.tar.gz
-    cd 
-    tar xf  $__tmp/master.tar.gz
+    tar xf master.tar.gz
     mv Perspectives-Server-master Perspectives-Server
     chmod +x Perspectives-Server/admin/*.sh
 }


### PR DESCRIPTION
## Summary
- \`recipes/notary\`'s \`_build()\` had a bare \`cd\` (no argument) after downloading the tarball, which jumps to \`\$HOME\` instead of staying in the temp build directory spm already \`cd\`'d into.
- As a result, the source tarball was extracted into the user's home directory and left there (the throwaway tmp dir was bypassed entirely), and the subsequent \`mv\`/\`chmod\` only worked because they happened to operate on \$HOME by accident.
- Removed the stray \`cd\` and switched the \`tar\` invocation to the relative filename, matching the pattern used by every other recipe in this repo (e.g. \`gnulib\`, \`dnscrypt-wrapper\`).

## Test plan
- [x] \`bash -n recipes/notary\` (syntax check)
- [ ] \`./spm install notary\`, confirm \`Perspectives-Server\` ends up under the temp build dir and nothing is left in \$HOME